### PR TITLE
Parse code 429 to resource exhausted

### DIFF
--- a/lib/src/http_response_parser.dart
+++ b/lib/src/http_response_parser.dart
@@ -106,7 +106,7 @@ class HttpResponseParser {
       case 404:
         return ErrorCode.BadRoute;
       case 429:
-        return ErrorCode.Unavailable;
+        return ErrorCode.ResourceExhausted;
       case 502:
         return ErrorCode.Unavailable;
       case 503:


### PR DESCRIPTION
Backend returns 429 as resource exhausted when call gets rate limited.